### PR TITLE
.NET Core SDK 2.2 Support and update tests to support product_id requirement on Fills

### DIFF
--- a/Gdax.Tests/Fills/GetFillsQueryTests.cs
+++ b/Gdax.Tests/Fills/GetFillsQueryTests.cs
@@ -17,7 +17,7 @@ namespace Gdax.Fills
 				UseSandbox = true
 			};
 
-			var fills = await client.GetFills();
+			var fills = await client.GetFills(productId: "BTC-USD");
 
 			fills.ShouldNotBeNull();
 		}
@@ -38,18 +38,19 @@ namespace Gdax.Fills
 				await client.DepositFromCoinbase(10, btcAccount.Currency, btcAccount.Id);
 			}
 
-			await client.PlaceMarketOrder(Side.Sell, "BTC-USD", 0.01m);
-			await client.PlaceMarketOrder(Side.Sell, "BTC-USD", 0.02m);
-			await client.PlaceMarketOrder(Side.Sell, "BTC-USD", 0.03m);
-			await client.PlaceMarketOrder(Side.Sell, "BTC-USD", 0.04m);
+			var productId = "BTC-USD";
+			await client.PlaceMarketOrder(Side.Sell, productId, 0.01m);
+			await client.PlaceMarketOrder(Side.Sell, productId, 0.02m);
+			await client.PlaceMarketOrder(Side.Sell, productId, 0.03m);
+			await client.PlaceMarketOrder(Side.Sell, productId, 0.04m);
 
-			var fills = await client.GetFills(paging: new PagingOptions<Int32?>
+			var fills = await client.GetFills(productId: productId, paging: new PagingOptions<Int32?>
 			{
 				Limit = 1
 			});
 			
-			var fillsPage2 = await client.GetFills(paging: fills.NextPage());
-			var fillsPage1 = await client.GetFills(paging: fillsPage2.PreviousPage());
+			var fillsPage2 = await client.GetFills(productId: productId, paging: fills.NextPage());
+			var fillsPage1 = await client.GetFills(productId: productId, paging: fillsPage2.PreviousPage());
 
 			fills.ShouldNotBeNull();
 			fills.Results.ShouldHaveSingleItem();

--- a/Gdax.Tests/Gdax.Tests.csproj
+++ b/Gdax.Tests/Gdax.Tests.csproj
@@ -23,8 +23,4 @@
     <ProjectReference Include="..\Gdax\Gdax.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.0.0-preview2-006497"
+    "version": "2.2.101"
   }
 }


### PR DESCRIPTION
Fix issue #10 and #11 

- Support system with .NET Core SDK 2.2 and not 2.0.0-preview2-006497
- Fix error of "query must contained either product_id or order_id"
